### PR TITLE
Update gem version for Ruby 3.4

### DIFF
--- a/src/engines/ruby/3.4/Dockerfile
+++ b/src/engines/ruby/3.4/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.3.26
+RUN gem update --system 3.5.21
 RUN gem install bundler:2.3.26
 
 # Install additional gems that are in CRuby but missing from the above


### PR DESCRIPTION
For Ruby 3.4, update the gem to the newest version that supports Ruby 3.4 -- 2.5.21.