### PR TITLE
Update rubygem 3.5.21 

### DIFF
--- a/src/engines/jruby/9.4/Dockerfile
+++ b/src/engines/jruby/9.4/Dockerfile
@@ -68,7 +68,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.3.26
+RUN gem update --system 3.5.21
 RUN gem install bundler:2.3.26
 
 # Install additional gems that are in CRuby but missing from the above

--- a/src/engines/ruby/3.0/Dockerfile
+++ b/src/engines/ruby/3.0/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.3.26
+RUN gem update --system 3.5.21
 RUN gem install bundler:2.3.26
 
 # Install additional gems that are in CRuby but missing from the above

--- a/src/engines/ruby/3.1/Dockerfile
+++ b/src/engines/ruby/3.1/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.3.26
+RUN gem update --system 3.5.21
 RUN gem install bundler:2.3.26
 
 # Install additional gems that are in CRuby but missing from the above

--- a/src/engines/ruby/3.3/Dockerfile
+++ b/src/engines/ruby/3.3/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
  && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.3.26
+RUN gem update --system 3.5.21
 RUN gem install bundler:2.3.26
 
 # Install additional gems that are in CRuby but missing from the above


### PR DESCRIPTION
For Ruby 3+, conflict with uri version. 

To resolved: update rubygem version to 3.5.21