### PR TITLE
Add missing platform directive

### DIFF
--- a/src/engines/ruby/2.1/Dockerfile.musl
+++ b/src/engines/ruby/2.1/Dockerfile.musl
@@ -1,3 +1,4 @@
+# platforms: linux/x86_64
 FROM ruby:2.1-alpine
 
 # A few RUN actions in Dockerfiles are subject to uncontrollable outside


### PR DESCRIPTION
Overlooked that `engines/ruby:2.1-musl` behaves like `engines/ruby:2.2-musl`.

This impacts, say, `rake docker build[**:*]` but not CI since is is currently hardcoded in the workflow matrix.