### PR TITLE
Fix CentOS packages again (properly add g++ and other tools)

### DIFF
--- a/src/engines/ruby/1.8/Dockerfile.centos
+++ b/src/engines/ruby/1.8/Dockerfile.centos
@@ -70,7 +70,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/1.9/Dockerfile.centos
+++ b/src/engines/ruby/1.9/Dockerfile.centos
@@ -70,7 +70,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.0/Dockerfile.centos
+++ b/src/engines/ruby/2.0/Dockerfile.centos
@@ -70,7 +70,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.1/Dockerfile.centos
+++ b/src/engines/ruby/2.1/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.2/Dockerfile.centos
+++ b/src/engines/ruby/2.2/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.3/Dockerfile.centos
+++ b/src/engines/ruby/2.3/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.4/Dockerfile.centos
+++ b/src/engines/ruby/2.4/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.5/Dockerfile.centos
+++ b/src/engines/ruby/2.5/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.6/Dockerfile.centos
+++ b/src/engines/ruby/2.6/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/2.7/Dockerfile.centos
+++ b/src/engines/ruby/2.7/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/3.0/Dockerfile.centos
+++ b/src/engines/ruby/3.0/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/3.1/Dockerfile.centos
+++ b/src/engines/ruby/3.1/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/3.2/Dockerfile.centos
+++ b/src/engines/ruby/3.2/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/3.3/Dockerfile.centos
+++ b/src/engines/ruby/3.3/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors

--- a/src/engines/ruby/3.4/Dockerfile.centos
+++ b/src/engines/ruby/3.4/Dockerfile.centos
@@ -68,7 +68,7 @@ RUN true "${REPRO_RUN_KEY}" && yum makecache -y
 # fun: CentOS 8 has `yum list glibc-langpack-\*` but not CentOS 7 :'(
 RUN yum reinstall -y glibc-common
 
-RUN yum install -y curl gcc g++ make patch git
+RUN yum install -y curl gcc gcc-c++ gettext make patchutils patch libtool pkgconfig gettext file zip unzip git
 
 # fun: this has to be after `yum install curl gcc make`... but only on aarch64; go figure
 # extra fun: table is botched, localedef not happy, swallow result and test `locale` for errors


### PR DESCRIPTION
`yum` is a damning idiot and does not fail when you pass it an unknown package.

#40 is dearly needed.