### PR TITLE
[NO-TICKET] Add Redis 8 image

### DIFF
--- a/src/services/redis/8/Dockerfile
+++ b/src/services/redis/8/Dockerfile
@@ -1,0 +1,3 @@
+FROM redis:8
+
+LABEL org.opencontainers.image.source=https://github.com/DataDog/images-rb


### PR DESCRIPTION
Sidekiq tests are currently disabled on dd-trace-rb CI, the reason being it requires Redis 7 at least. But we only have an image of Redis 6.2. This PR adds a new image for Redis 8