### PR TITLE
Re-enable dependabot with 2-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       gh-actions-packages:
         patterns:
           - "*"
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a 2-day cooldown on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Dependabot configuration and introduces the cooldown setting. If you notice any other Dependabot configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.