### PR TITLE
Add memcached 1.6

### DIFF
--- a/src/services/memcached/1.6/Dockerfile.alpine
+++ b/src/services/memcached/1.6/Dockerfile.alpine
@@ -1,0 +1,3 @@
+FROM memcached:1.6-alpine
+
+LABEL org.opencontainers.image.source=https://github.com/DataDog/images-rb


### PR DESCRIPTION
Adding memcached 1.6 is necessary to be able to use dalli 5.x, as Dalli 5 uses the memcached meta protocol, which has been added in memcached 1.6. This should fix https://github.com/DataDog/dd-trace-rb/pull/5429