### PR TITLE
Add mongodb 4.2

### DIFF
--- a/src/services/mongo/4.2/Dockerfile
+++ b/src/services/mongo/4.2/Dockerfile
@@ -1,0 +1,3 @@
+FROM mongo:4.2
+
+LABEL org.opencontainers.image.source=https://github.com/DataDog/images-rb


### PR DESCRIPTION
`mongo` gem now requires at least MongoDB 4.2 (https://github.com/mongodb/mongo-ruby-driver/pull/2986)
It is necessary to run the CI on latest `mongo` gem