### PR TITLE
Upgrade RubyGems/Bundler to 4.0.16 for Ruby 3.2+

### DIFF
--- a/src/engines/ruby/3.2/Dockerfile.centos
+++ b/src/engines/ruby/3.2/Dockerfile.centos
@@ -174,7 +174,7 @@ rm -r /usr/src/ruby
 if yum list installed ruby; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.2/Dockerfile.gnu
+++ b/src/engines/ruby/3.2/Dockerfile.gnu
@@ -153,7 +153,7 @@ rm -r /usr/src/ruby
 if dpkg -l ruby 2>/dev/null | grep -q '^ii'; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.2/Dockerfile.musl
+++ b/src/engines/ruby/3.2/Dockerfile.musl
@@ -31,7 +31,7 @@ RUN true "${REPRO_RUN_KEY}" && apk update
 ENV LANG en_US.UTF-8
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.7.2
+RUN gem update --system 4.0.16
 
 # Install additional gems that are in CRuby but missing from the above
 # JRuby install distribution. These are version-pinned for reproducibility.

--- a/src/engines/ruby/3.3/Dockerfile.centos
+++ b/src/engines/ruby/3.3/Dockerfile.centos
@@ -174,7 +174,7 @@ rm -r /usr/src/ruby
 if yum list installed ruby; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.3/Dockerfile.gnu
+++ b/src/engines/ruby/3.3/Dockerfile.gnu
@@ -153,7 +153,7 @@ rm -r /usr/src/ruby
 if dpkg -l ruby 2>/dev/null | grep -q '^ii'; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.3/Dockerfile.musl
+++ b/src/engines/ruby/3.3/Dockerfile.musl
@@ -31,7 +31,7 @@ RUN true "${REPRO_RUN_KEY}" && apk update
 ENV LANG en_US.UTF-8
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.7.2
+RUN gem update --system 4.0.16
 
 # Install additional gems that are in CRuby but missing from the above
 # JRuby install distribution. These are version-pinned for reproducibility.

--- a/src/engines/ruby/3.4/Dockerfile.centos
+++ b/src/engines/ruby/3.4/Dockerfile.centos
@@ -174,7 +174,7 @@ rm -r /usr/src/ruby
 if yum list installed ruby; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.4/Dockerfile.gnu
+++ b/src/engines/ruby/3.4/Dockerfile.gnu
@@ -153,7 +153,7 @@ rm -r /usr/src/ruby
 if dpkg -l ruby 2>/dev/null | grep -q '^ii'; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.4/Dockerfile.musl
+++ b/src/engines/ruby/3.4/Dockerfile.musl
@@ -31,7 +31,7 @@ RUN true "${REPRO_RUN_KEY}" && apk update
 ENV LANG en_US.UTF-8
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.7.2
+RUN gem update --system 4.0.16
 
 # Install additional gems that are in CRuby but missing from the above
 # JRuby install distribution. These are version-pinned for reproducibility.

--- a/src/engines/ruby/3.5/Dockerfile.centos
+++ b/src/engines/ruby/3.5/Dockerfile.centos
@@ -200,7 +200,7 @@ rm -r /usr/src/ruby
 if yum list installed ruby; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.5/Dockerfile.gnu
+++ b/src/engines/ruby/3.5/Dockerfile.gnu
@@ -153,7 +153,7 @@ rm -r /usr/src/ruby
 if dpkg -l ruby 2>/dev/null | grep -q '^ii'; then exit 1; fi
 
 # update gem version
-gem update --system 3.7.2
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/3.5/Dockerfile.musl
+++ b/src/engines/ruby/3.5/Dockerfile.musl
@@ -31,7 +31,7 @@ RUN true "${REPRO_RUN_KEY}" && apk update
 ENV LANG en_US.UTF-8
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 3.7.2
+RUN gem update --system 4.0.16
 
 # Install additional gems that are in CRuby but missing from the above
 # JRuby install distribution. These are version-pinned for reproducibility.

--- a/src/engines/ruby/4.0/Dockerfile.centos
+++ b/src/engines/ruby/4.0/Dockerfile.centos
@@ -224,7 +224,7 @@ rm -r /usr/src/ruby
 if yum list installed ruby; then exit 1; fi
 
 # update gem version
-gem update --system 4.0.6
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/4.0/Dockerfile.gnu
+++ b/src/engines/ruby/4.0/Dockerfile.gnu
@@ -153,7 +153,7 @@ rm -r /usr/src/ruby
 if dpkg -l ruby 2>/dev/null | grep -q '^ii'; then exit 1; fi
 
 # update gem version
-gem update --system 4.0.6
+gem update --system 4.0.16
 
 # rough smoke test
 ruby --version

--- a/src/engines/ruby/4.0/Dockerfile.musl
+++ b/src/engines/ruby/4.0/Dockerfile.musl
@@ -31,7 +31,7 @@ RUN true "${REPRO_RUN_KEY}" && apk update
 ENV LANG en_US.UTF-8
 
 ## Install a pinned RubyGems and Bundler
-RUN gem update --system 4.0.6
+RUN gem update --system 4.0.16
 
 # Install additional gems that are in CRuby but missing from the above
 # JRuby install distribution. These are version-pinned for reproducibility.


### PR DESCRIPTION
## Summary

- Ruby 3.2–3.5: upgrade `gem update --system` from `3.7.2` → `4.0.16` (Bundler 2.7.2 → 4.0.16)
- Ruby 4.0: patch bump from `4.0.6` → `4.0.16`

All variants updated (gnu, musl, centos) for consistency.

RubyGems/Bundler 4.0.x requires Ruby >= 3.2, so older Rubies (2.5–3.1) are left on their current series — they are already at the latest compatible patch for their respective RubyGems minor series.

## Test plan

- [ ] `rake docker:build[ruby/3.2:gnu]` and verify `bundle --version` → `4.0.16`
- [ ] `rake docker:build[ruby/4.0:gnu]` and verify `bundle --version` → `4.0.16`
- [ ] CI matrix passes for all modified images