### PR TITLE
Grant packages:write to Ruby build workflows for manual dispatch

### DIFF
--- a/.github/workflows/build-ruby-compilers.yml
+++ b/.github/workflows/build-ruby-compilers.yml
@@ -1,5 +1,8 @@
 name: Build Ruby Compilers
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -1,5 +1,8 @@
 name: Build Ruby
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,8 @@
 name: Ruby
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

- Adds `permissions: packages: write` at the top level of `ruby.yml`, `build-ruby.yml`, and `build-ruby-compilers.yml`.
- Manually triggering these workflows via `workflow_dispatch` (e.g. to publish images with `push: true`) currently fails, because `workflow_dispatch` runs are capped at the repo's default token permissions (`packages: read`), and the nested `_build-image.yml` job requests `packages: write`.
- `main.yml` already grants `packages: write` at the job level when calling these as reusable workflows on `push`, so this only fills the gap for the manual dispatch path — no change to existing push-triggered behavior.

These permissions: blocks are declared at the job level inside the reusable workflow _build-image.yml. Each job runs steps that log in to the container registry and push images/manifests (e.g. docker push, docker manifest push for the multiarch release tag) — hence they explicitly request packages: write.

GitHub enforces that a caller workflow's effective token permissions must be at least as permissive as what a nested/reusable workflow's jobs request. Since ruby.yml → build-ruby.yml → _build-image.yml had no permissions: block declared anywhere in the caller chain when triggered via workflow_dispatch, GitHub fell back to the repo's default (packages: read), which is less than the packages: write these two jobs explicitly require — causing the startup failure. That's the gap PR #92 closes by adding permissions: packages: write to the caller workflows.

## Failed run

Dispatching `Ruby` manually with `push: true` fails immediately with a startup failure:

https://github.com/DataDog/images-rb/actions/runs/29567133724

```
Invalid workflow file: .github/workflows/build-ruby.yml#L27
The workflow is not valid. .github/workflows/build-ruby.yml (Line: 27, Col: 3): Error calling workflow 'DataDog/images-rb/.github/workflows/_build-image.yml@818801b7678a58516deb57e08b1b43e6477f5ec1'. The nested job 'build' is requesting 'packages: write', but is only allowed 'packages: read'.
.github/workflows/build-ruby.yml (Line: 27, Col: 3): Error calling workflow 'DataDog/images-rb/.github/workflows/_build-image.yml@818801b7678a58516deb57e08b1b43e6477f5ec1'. The nested job 'join' is requesting 'packages: write', but is only allowed 'packages: read'.
```