### PR TITLE
Add pkg-config to Ruby gnu images

### DIFF
--- a/src/engines/ruby/1.8/Dockerfile.gnu
+++ b/src/engines/ruby/1.8/Dockerfile.gnu
@@ -73,6 +73,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/1.9/Dockerfile.gnu
+++ b/src/engines/ruby/1.9/Dockerfile.gnu
@@ -73,6 +73,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.0/Dockerfile.gnu
+++ b/src/engines/ruby/2.0/Dockerfile.gnu
@@ -73,6 +73,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.1/Dockerfile.gnu
+++ b/src/engines/ruby/2.1/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.2/Dockerfile.gnu
+++ b/src/engines/ruby/2.2/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.3/Dockerfile.gnu
+++ b/src/engines/ruby/2.3/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.4/Dockerfile.gnu
+++ b/src/engines/ruby/2.4/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.5/Dockerfile.gnu
+++ b/src/engines/ruby/2.5/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.6/Dockerfile.gnu
+++ b/src/engines/ruby/2.6/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/2.7/Dockerfile.gnu
+++ b/src/engines/ruby/2.7/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.0/Dockerfile.gnu
+++ b/src/engines/ruby/3.0/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.1/Dockerfile.gnu
+++ b/src/engines/ruby/3.1/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.2/Dockerfile.gnu
+++ b/src/engines/ruby/3.2/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.3/Dockerfile.gnu
+++ b/src/engines/ruby/3.3/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.4/Dockerfile.gnu
+++ b/src/engines/ruby/3.4/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/3.5/Dockerfile.gnu
+++ b/src/engines/ruby/3.5/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \

--- a/src/engines/ruby/4.0/Dockerfile.gnu
+++ b/src/engines/ruby/4.0/Dockerfile.gnu
@@ -72,6 +72,7 @@ apt-get install -y \
     bison \
     patch \
     libc6-dev \
+    pkg-config \
     build-essential \
     git \
     xz-utils \


### PR DESCRIPTION
## Summary

`Dockerfile.gnu` for every Ruby version (1.8–4.0) builds Ruby from source on top of a bare `debian:11` image with a hand-picked `apt-get install` list. That list never included `pkg-config`, unlike the official `ruby:X.Y-bullseye` images these Dockerfiles replaced in c29a4c1 ("Build all `-gnu` from source"), which included it transitively.

This went unnoticed for months because previously-published `ghcr.io/datadog/images-rb/engines/ruby:*` tags still served the old, working image content. It surfaced today after a manual republish overwrote the `ruby:2.7` tag with a freshly built image lacking `pkg-config`, which broke `bundle install` in dd-trace-rb/system-tests CI: native gems that vendor-build their own library (e.g. `sqlite3` via `mini_portile2`) still need the `pkg-config` binary to read the `.pc` file the vendored build produces, and fail with `Could not configure the build properly (pkg_config)` otherwise.

Adds `pkg-config` to the `apt-get install` list in all 17 `Dockerfile.gnu` files, right after `libc6-dev`, matching each file's existing formatting. Scope is `gnu` only — `musl` and `centos` were checked and also lack `pkg-config`, but neither has an observed failure, so they're left untouched pending confirmation of their own package-manager equivalents.

## Test plan

- [ ] Built `src/engines/ruby/2.7/Dockerfile.gnu` locally with the fix and ran `bundle install` against system-tests' `rails52` `Gemfile` (which pulls `sqlite3 1.7.3` / `mini_portile2`) — completes successfully, including the vendored SQLite build and `pkg_config` activation step that previously failed.
- [ ] CI matrix passes for all modified images