### PR TITLE
Add libsqlite3-dev to Ruby 2.5 gnu image

### DIFF
--- a/src/engines/ruby/2.5/Dockerfile.gnu
+++ b/src/engines/ruby/2.5/Dockerfile.gnu
@@ -83,6 +83,7 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"


### PR DESCRIPTION
## Summary

`Dockerfile.gnu` for Ruby 2.5 builds Ruby from source on top of a bare `debian:11` image with a hand-picked `apt-get install` list. That list never included `libsqlite3-dev`, unlike the official `ruby:2.5-bullseye` image it replaced in c29a4c1 ("Build all `-gnu` from source"), which included it transitively — confirmed by pulling `ruby:2.5.9-buster` and checking `/usr/include/sqlite3.h` was present.

This went unnoticed because it only affects consumers that link against the system SQLite library. `sqlite3` gem >= 1.4 vendor-builds its own SQLite via `mini_portile2` and only needs the `pkg-config` binary (fixed for all Ruby versions in #94); `sqlite3` < 1.4 instead links against system SQLite and needs `sqlite3.h` from `libsqlite3-dev`. Of the Ruby versions built from source here, only Ruby 2.5's dd-trace-rb/system-tests consumer (`rails42`, testing Rails 4.2.11.3) pins `sqlite3 < 1.4` — every other weblog across every other Ruby version uses `sqlite3 1.7.3+`. This surfaced as a `bundle install` failure (`checking for sqlite3.h... no`, `Gem::Ext::BuildError`) after a manual republish of the `ruby:2.5` tag.

Adds `libsqlite3-dev` to the `apt-get install` list in `src/engines/ruby/2.5/Dockerfile.gnu` only, right after `libssl-dev`. Scoped to 2.5 because it is the only Ruby version with a consumer pinned below `sqlite3 1.4`; verified via each weblog's `Gemfile.lock`.

## Test plan

- [x] Built `src/engines/ruby/2.5/Dockerfile.gnu` locally with the fix and ran `bundle install` against system-tests' `rails42` `Gemfile` (pinned to `sqlite3 < 1.4`) — completes successfully, including native extension build against system `sqlite3.h`.
- [x] Ran `bundle exec rake db:create db:migrate db:seed` against the same image — completes successfully with traced SQLite queries.
- [ ] CI matrix passes for the modified image