### PR TITLE
Add test asserting pkg-config is present in built images

### DIFF
--- a/test/engines/test_packages.rb
+++ b/test/engines/test_packages.rb
@@ -1,0 +1,12 @@
+require "minitest/autorun"
+
+class TestPackages < Minitest::Test
+  def test_pkg_config_present
+    path = ENV["PATH"].to_s.split(File::PATH_SEPARATOR).find do |dir|
+      File.executable?(File.join(dir, "pkg-config"))
+    end
+
+    refute_nil(path, "pkg-config not found on PATH")
+    assert(system("pkg-config", "--version", out: File::NULL), "pkg-config --version failed")
+  end
+end


### PR DESCRIPTION
## Summary

#94 and #95 both fixed regressions from c29a4c1 ("Build all `-gnu` from source") where the from-source rebuild silently dropped packages (`pkg-config`, `libsqlite3-dev`) that the official base images had included transitively. Neither regression was caught by CI — the existing smoke tests (`ruby --version`, `gem --version`, `bundle --version` in `_build-image.yml`) don't check for `pkg-config`, and there was no dedicated content-verification test for it either.

Adds `test/engines/test_packages.rb`, a Minitest suite that asserts `pkg-config` is present on `PATH` and runs successfully. This runs inside every built image via the existing `bundle exec rake test` step in `_build-image.yml`'s `Test image` step, so it automatically covers every engine/version/libc/arch combination in the build matrix without any workflow YAML changes. Checking for the `pkg-config` binary directly (rather than querying the package manager) keeps the test portable across gnu (apt), musl (apk), and centos (yum, where the package is actually named `pkgconfig`).

## Test plan

- [x] Ran the test against a Ruby 2.5 gnu image built from `c29a4c1` (before #94) — fails with `pkg-config not found on PATH`.
- [x] Ran the test against the current (fixed) Ruby 2.5 gnu image — passes.
- [ ] CI matrix passes across all engines/versions/libc flavors