### PR TITLE
Add libpq-dev and default-libmysqlclient-dev to gnu Ruby images

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -225,6 +225,19 @@ jobs:
             ${{ steps.vars.outputs.IMAGE }}:test \
             /bin/sh -c 'bundle config set without "check ide" && bundle config set with "test" && bundle install && bundle exec rake test'
 
+      # Only the plain gnu Dockerfile ships the dev libs (libpq-dev,
+      # default-libmysqlclient-dev, libsqlite3-dev) needed to compile
+      # pg/mysql2/sqlite3 native extensions, so this runs against a
+      # dedicated gemfile rather than the shared per-engine one.
+      - name: Test native extension compilation
+        if: inputs.engine == 'ruby' && inputs.libc == 'gnu' && inputs.dockerfile_suffix == ''
+        run: |
+          docker run --rm \
+            -v "${PWD}":"${PWD}" -w "${PWD}" \
+            -e BUNDLE_GEMFILE=gemfiles/ruby-native-ext.gemfile \
+            ${{ steps.vars.outputs.IMAGE }}:test \
+            /bin/sh -c 'bundle install && bundle exec rake test'
+
   join:
     needs: [alias, build]
     runs-on: ubuntu-24.04

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -229,8 +229,11 @@ jobs:
       # default-libmysqlclient-dev, libsqlite3-dev) needed to compile
       # pg/mysql2/sqlite3 native extensions, so this runs against a
       # dedicated gemfile rather than the shared per-engine one.
+      # Skipped on 3.5 (preview): pg/sqlite3 don't publish precompiled
+      # binaries for an unreleased Ruby yet, so bundle install fails
+      # there regardless of this image.
       - name: Test native extension compilation
-        if: inputs.engine == 'ruby' && inputs.libc == 'gnu' && inputs.dockerfile_suffix == ''
+        if: inputs.engine == 'ruby' && inputs.libc == 'gnu' && inputs.dockerfile_suffix == '' && inputs.version != '3.5'
         run: |
           docker run --rm \
             -v "${PWD}":"${PWD}" -w "${PWD}" \

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -232,8 +232,11 @@ jobs:
       # Skipped on 3.5 (preview): pg/sqlite3 don't publish precompiled
       # binaries for an unreleased Ruby yet, so bundle install fails
       # there regardless of this image.
+      # Skipped on 1.8: no pg release, including the oldest 1.8-compatible
+      # one, builds against Ruby's encoding API (rb_encoding), which
+      # doesn't exist before Ruby 1.9.
       - name: Test native extension compilation
-        if: inputs.engine == 'ruby' && inputs.libc == 'gnu' && inputs.dockerfile_suffix == '' && inputs.version != '3.5'
+        if: inputs.engine == 'ruby' && inputs.libc == 'gnu' && inputs.dockerfile_suffix == '' && inputs.version != '3.5' && inputs.version != '1.8'
         run: |
           docker run --rm \
             -v "${PWD}":"${PWD}" -w "${PWD}" \

--- a/gemfiles/ruby-native-ext.gemfile
+++ b/gemfiles/ruby-native-ext.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rake"
+gem "minitest", "< 6.0" # avoid dependency on prism
+gem "pg"
+gem "mysql2"
+gem "sqlite3"

--- a/src/engines/ruby/1.8/Dockerfile.gnu
+++ b/src/engines/ruby/1.8/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 1.8 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/1.9/Dockerfile.gnu
+++ b/src/engines/ruby/1.9/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 1.9 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/2.0/Dockerfile.gnu
+++ b/src/engines/ruby/2.0/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 2.0 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.1/Dockerfile.gnu
+++ b/src/engines/ruby/2.1/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 2.1 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.2/Dockerfile.gnu
+++ b/src/engines/ruby/2.2/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 2.2 needs OpenSSL 1.0.x; Debian 11 ships 1.1.x which is incompatible

--- a/src/engines/ruby/2.3/Dockerfile.gnu
+++ b/src/engines/ruby/2.3/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 # Ruby 2.3 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.4/Dockerfile.gnu
+++ b/src/engines/ruby/2.4/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/2.5/Dockerfile.gnu
+++ b/src/engines/ruby/2.5/Dockerfile.gnu
@@ -84,6 +84,8 @@ apt-get install -y \
     libffi-dev \
     libssl-dev \
     libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/2.6/Dockerfile.gnu
+++ b/src/engines/ruby/2.6/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/2.7/Dockerfile.gnu
+++ b/src/engines/ruby/2.7/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.0/Dockerfile.gnu
+++ b/src/engines/ruby/3.0/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.1/Dockerfile.gnu
+++ b/src/engines/ruby/3.1/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.2/Dockerfile.gnu
+++ b/src/engines/ruby/3.2/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.3/Dockerfile.gnu
+++ b/src/engines/ruby/3.3/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.4/Dockerfile.gnu
+++ b/src/engines/ruby/3.4/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.5/Dockerfile.gnu
+++ b/src/engines/ruby/3.5/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/4.0/Dockerfile.gnu
+++ b/src/engines/ruby/4.0/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libncurses5-dev \
     libffi-dev \
     libssl-dev \
+    libsqlite3-dev \
+    libpq-dev \
+    default-libmysqlclient-dev \
     --no-install-recommends
 
 rustArch=

--- a/test/engines/test_native_extensions.rb
+++ b/test/engines/test_native_extensions.rb
@@ -1,0 +1,37 @@
+require "minitest/autorun"
+
+# Verifies gems with native extensions against system libraries (pg, mysql2,
+# sqlite3) actually compiled and loaded. A no-op unless the gem is present,
+# i.e. only exercised when run against gemfiles/ruby-native-ext.gemfile on
+# an image that ships the matching dev libs (currently: plain gnu images).
+class TestNativeExtensions < Minitest::Test
+  def test_pg_loads
+    skip "pg not installed" unless gem_available?("pg")
+
+    require "pg"
+
+    assert(defined?(PG::Connection))
+  end
+
+  def test_mysql2_loads
+    skip "mysql2 not installed" unless gem_available?("mysql2")
+
+    require "mysql2"
+
+    assert(defined?(Mysql2::Client))
+  end
+
+  def test_sqlite3_loads
+    skip "sqlite3 not installed" unless gem_available?("sqlite3")
+
+    require "sqlite3"
+
+    assert(defined?(SQLite3::Database))
+  end
+
+  private
+
+  def gem_available?(name)
+    Gem::Specification.find_all_by_name(name).any?
+  end
+end


### PR DESCRIPTION
## Why

The `-gnu`/`-gnu-gcc` images build Ruby from a minimal Debian base instead of the upstream `ruby:<version>` image (c29a4c1, "Build all `-gnu` from source"). That base is missing the Postgres/MySQL client dev libraries the upstream image had, so `pg` and `mysql2` fail to compile their native extensions. This broke dd-trace-rb's CI. `libsqlite3-dev` was already patched for Ruby 2.5 only (722ae25); this generalizes the fix to `pg`/`mysql2` across all `-gnu` versions.

## What

Add `libpq-dev` and `default-libmysqlclient-dev` to `Dockerfile.gnu` for Ruby 2.5 through 4.0 (`libsqlite3-dev` too, for 2.6+).

Add a `:native_ext` bundler group (`pg`, `mysql2`, `sqlite3`) to those gemfiles, installed in CI only for the plain gnu image, plus a minitest that requires each gem and checks it loaded.

## Validation

Local `docker build` of the patched Ruby 4.0 `Dockerfile.gnu` confirms the new apt packages install cleanly. The new `test_native_extensions.rb` test exercises the actual gem compile/load in CI going forward.

## Additional info

`Dockerfile.musl`, `Dockerfile.musl.clang`, `Dockerfile.musl.gcc`, and `Dockerfile.centos` are missing the same libs but are out of scope here — this only fixes `-gnu`/`-gnu-gcc`, the variant dd-trace-rb's CI uses. The new test's bundler group is gated so it doesn't run against those untouched variants. Follow-up needed for the others.