### PR TITLE
Restore database development packages

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -224,6 +224,15 @@ jobs:
             -e BUNDLE_GEMFILE=gemfiles/${{ inputs.engine }}-${{ inputs.version }}.gemfile \
             ${{ steps.vars.outputs.IMAGE }}:test \
             /bin/sh -c 'bundle config set without "check ide" && bundle config set with "test" && bundle install && bundle exec rake test'
+          # Ruby 2.5 is the oldest GNU image used by dd-trace-rb. Verify the
+          # development packages can compile and load each database extension.
+          if [ "${{ inputs.engine }}:${{ inputs.version }}:${{ inputs.libc }}" = ruby:2.5:gnu ]; then
+            docker run --rm ${{ steps.vars.outputs.IMAGE }}:test /bin/sh -c \
+              'gem install sqlite3 -v 1.3.13 --platform ruby --no-document &&
+               gem install mysql2 -v 0.5.7 --no-document &&
+               gem install pg -v 1.5.9 --platform ruby --no-document &&
+               ruby -rsqlite3 -rmysql2 -rpg -e "db = SQLite3::Database.new(\":memory:\"); abort unless db.get_first_value(\"SELECT 1\") == 1; abort unless Mysql2::Client.info[:version]; abort unless PG.library_version > 0"'
+          fi
 
   join:
     needs: [alias, build]

--- a/src/engines/ruby/1.8/Dockerfile.gnu
+++ b/src/engines/ruby/1.8/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 1.8 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/1.9/Dockerfile.gnu
+++ b/src/engines/ruby/1.9/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 1.9 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/2.0/Dockerfile.gnu
+++ b/src/engines/ruby/2.0/Dockerfile.gnu
@@ -83,6 +83,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 2.0 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.1/Dockerfile.gnu
+++ b/src/engines/ruby/2.1/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 2.1 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.2/Dockerfile.gnu
+++ b/src/engines/ruby/2.2/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 2.2 needs OpenSSL 1.0.x; Debian 11 ships 1.1.x which is incompatible

--- a/src/engines/ruby/2.3/Dockerfile.gnu
+++ b/src/engines/ruby/2.3/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     --no-install-recommends
 
 # Ruby 2.3 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.4/Dockerfile.gnu
+++ b/src/engines/ruby/2.4/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/2.5/Dockerfile.gnu
+++ b/src/engines/ruby/2.5/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     libsqlite3-dev \
     --no-install-recommends

--- a/src/engines/ruby/2.6/Dockerfile.gnu
+++ b/src/engines/ruby/2.6/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/2.7/Dockerfile.gnu
+++ b/src/engines/ruby/2.7/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.0/Dockerfile.gnu
+++ b/src/engines/ruby/3.0/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.1/Dockerfile.gnu
+++ b/src/engines/ruby/3.1/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.2/Dockerfile.gnu
+++ b/src/engines/ruby/3.2/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.3/Dockerfile.gnu
+++ b/src/engines/ruby/3.3/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.4/Dockerfile.gnu
+++ b/src/engines/ruby/3.4/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/3.5/Dockerfile.gnu
+++ b/src/engines/ruby/3.5/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 

--- a/src/engines/ruby/4.0/Dockerfile.gnu
+++ b/src/engines/ruby/4.0/Dockerfile.gnu
@@ -82,6 +82,9 @@ apt-get install -y \
     libreadline-dev \
     libncurses5-dev \
     libffi-dev \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libpq-dev \
     libssl-dev \
     --no-install-recommends
 


### PR DESCRIPTION
## Summary
Restores the MySQL/MariaDB and PostgreSQL development dependencies previously inherited from the official Ruby base images.

The source-built GNU images no longer contain these packages, causing consumers that compile native database gems to fail. In particular, dd-trace-rb CI fails while compiling mysql2 because -lmysqlclient is unavailable.

Includes:
- libmariadb-dev for MariaDB headers and libraries
- libmariadb-dev-compat for the libmysqlclient.so and mysql_config compatibility interfaces expected by mysql2
- libpq-dev for PostgreSQL headers and libraries used by pg

## Validation
- Confirmed ruby:3.3-bookworm, the previous base image, includes these dependencies.
- Installed the packages into the current static 3.3-gnu-gcc image.
- Compiled and loaded mysql2 0.5.7 and pg 1.6.3 successfully.
- Verified all 17 GNU Ruby Dockerfiles include each package.
- Ran git diff --check.