### PR TITLE
Restore SQLite development headers

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -225,15 +225,22 @@ jobs:
             -e BUNDLE_GEMFILE=gemfiles/${{ inputs.engine }}-${{ inputs.version }}.gemfile \
             ${{ steps.vars.outputs.IMAGE }}:test \
             /bin/sh -c 'bundle config set without "check ide" && bundle config set with "test" && bundle install && bundle exec rake test'
-          # Ruby 2.5 is the oldest GNU image used by dd-trace-rb. Verify the
-          # development packages can compile and load each database extension.
-          if [ "${{ inputs.engine }}:${{ inputs.version }}:${{ inputs.libc }}" = ruby:2.5:gnu ]; then
-            docker run --rm ${{ steps.vars.outputs.IMAGE }}:test /bin/sh -c \
-              'gem install sqlite3 -v 1.3.13 --platform ruby --no-document &&
+          # GNU Ruby images used by dd-trace-rb must compile each database
+          # extension from source against the development packages they carry.
+          case "${{ inputs.engine }}:${{ inputs.libc }}:${{ inputs.version }}" in
+            ruby:gnu:2.[5-7]|ruby:gnu:3.[0-5]|ruby:gnu:4.0)
+              case "${{ inputs.version }}" in
+                2.[5-7]) sqlite_version=1.4.4 ;;
+                3.[0-3]) sqlite_version=1.6.6 ;;
+                3.[4-5]|4.0) sqlite_version=1.7.3 ;;
+              esac
+            docker run --rm -e "SQLITE_VERSION=$sqlite_version" ${{ steps.vars.outputs.IMAGE }}:test /bin/sh -c \
+              'gem install sqlite3 -v "$SQLITE_VERSION" --platform ruby --no-document &&
                gem install mysql2 -v 0.5.7 --no-document &&
                gem install pg -v 1.5.9 --platform ruby --no-document &&
                ruby -rsqlite3 -rmysql2 -rpg -e "db = SQLite3::Database.new(\":memory:\"); abort unless db.get_first_value(\"SELECT 1\") == 1; abort unless Mysql2::Client.info[:version]; abort unless PG.library_version > 0"'
-          fi
+              ;;
+          esac
 
   join:
     needs: [alias, build]

--- a/src/engines/ruby/1.8/Dockerfile.gnu
+++ b/src/engines/ruby/1.8/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 1.8 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/1.9/Dockerfile.gnu
+++ b/src/engines/ruby/1.9/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 1.9 needs OpenSSL 1.0.x; Debian 11's OpenSSL 1.1.x is incompatible

--- a/src/engines/ruby/2.0/Dockerfile.gnu
+++ b/src/engines/ruby/2.0/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 2.0 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.1/Dockerfile.gnu
+++ b/src/engines/ruby/2.1/Dockerfile.gnu
@@ -85,6 +85,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 2.1 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.2/Dockerfile.gnu
+++ b/src/engines/ruby/2.2/Dockerfile.gnu
@@ -85,6 +85,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 2.2 needs OpenSSL 1.0.x; Debian 11 ships 1.1.x which is incompatible

--- a/src/engines/ruby/2.3/Dockerfile.gnu
+++ b/src/engines/ruby/2.3/Dockerfile.gnu
@@ -85,6 +85,7 @@ apt-get install -y \
     libmariadb-dev \
     libmariadb-dev-compat \
     libpq-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 # Ruby 2.3 needs OpenSSL 1.0.x; Debian 11 ships OpenSSL 1.1.x which is incompatible

--- a/src/engines/ruby/2.4/Dockerfile.gnu
+++ b/src/engines/ruby/2.4/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/2.6/Dockerfile.gnu
+++ b/src/engines/ruby/2.6/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/2.7/Dockerfile.gnu
+++ b/src/engines/ruby/2.7/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.0/Dockerfile.gnu
+++ b/src/engines/ruby/3.0/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.1/Dockerfile.gnu
+++ b/src/engines/ruby/3.1/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 curl -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"

--- a/src/engines/ruby/3.2/Dockerfile.gnu
+++ b/src/engines/ruby/3.2/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.3/Dockerfile.gnu
+++ b/src/engines/ruby/3.3/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.4/Dockerfile.gnu
+++ b/src/engines/ruby/3.4/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/3.5/Dockerfile.gnu
+++ b/src/engines/ruby/3.5/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 rustArch=

--- a/src/engines/ruby/4.0/Dockerfile.gnu
+++ b/src/engines/ruby/4.0/Dockerfile.gnu
@@ -86,6 +86,7 @@ apt-get install -y \
     libmariadb-dev-compat \
     libpq-dev \
     libssl-dev \
+    libsqlite3-dev \
     --no-install-recommends
 
 rustArch=


### PR DESCRIPTION
## Summary
Restores libsqlite3-dev to every GNU Ruby image. The source-built images retained it only for Ruby 2.5, leaving Ruby 2.6 and later unable to compile sqlite3 from source.

Adds one smoke-test path for every GNU CRuby image from 2.5 onward. It compiles and loads sqlite3, mysql2, and pg from source using the development packages in the image.

SQLite versions follow the dd-trace-rb dependency matrix:
- Ruby 2.5 through 2.7: 1.4.4
- Ruby 3.0 through 3.3: 1.6.6
- Ruby 3.4 through 4.0: 1.7.3

## Validation
- Confirmed the published 2.7 GNU image lacks libsqlite3-dev while 2.5 includes it.
- Compiled and loaded sqlite3, mysql2, and pg against the CI-built GNU images for Ruby 2.5 through 4.0.
- Ran git diff --check and actionlint.