### PR TITLE
Promote qualified image tag aliases

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -301,12 +301,19 @@ jobs:
             ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.RUNID_TAG }}
 
       - name: Create and push multiarch manifest aliases
-        if: ${{ inputs.push }}
         env:
           ALIAS_TAGS: ${{ needs.alias.outputs.tags }}
         run: |
           while IFS= read -r tag; do
             docker buildx imagetools create \
-              -t ${{ steps.vars.outputs.IMAGE }}:"$tag" \
+              -t ${{ steps.vars.outputs.IMAGE }}:"$tag-gha${{ github.run_id }}-g${{ github.sha }}" \
               ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.RUNID_TAG }}
+            docker buildx imagetools create \
+              -t ${{ steps.vars.outputs.IMAGE }}:"$tag-g${{ github.sha }}" \
+              ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.RUNID_TAG }}
+            if [ "${{ inputs.push }}" = true ]; then
+              docker buildx imagetools create \
+                -t ${{ steps.vars.outputs.IMAGE }}:"$tag" \
+                ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.RUNID_TAG }}
+            fi
           done < <(jq -r '.[]' <<< "$ALIAS_TAGS")


### PR DESCRIPTION
## Summary
- promote every Dockerfile-derived alias to run- and commit-qualified manifests
- retain unqualified alias promotion only for push-enabled runs
- mirror the canonical tag lifecycle for aliases

## Verification
- parsed `.github/workflows/_build-image.yml` as YAML
- simulated `push: false` and `push: true` promotions for `4.0` and `4.0-gnu-gcc`
- ran Actionlint; it reports pre-existing ShellCheck findings in other workflow blocks