### PR TITLE
Centralise image publishing

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -42,6 +42,8 @@ jobs:
   alias:
     name: Alias (${{ inputs.engine }}:${{ inputs.version }}-${{ inputs.libc }}${{ inputs.tag_suffix }})
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       tags: ${{ steps.aliases.outputs.tags }}
     steps:
@@ -89,6 +91,7 @@ jobs:
         arch: ${{ fromJSON(inputs.arch) }}
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
+      contents: read
       packages: write
     name: Build (${{ inputs.engine }}:${{ inputs.version }}-${{ inputs.libc }}${{ inputs.tag_suffix }}, ${{ matrix.arch }})
     steps:

--- a/.github/workflows/build-ruby-compilers.yml
+++ b/.github/workflows/build-ruby-compilers.yml
@@ -1,24 +1,10 @@
 name: Build Ruby Compilers
 
 permissions:
+  contents: read
   packages: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      push:
-        description: Push images
-        required: true
-        type: boolean
-        default: true
-      dockerfile_suffix:
-        description: "Dockerfile suffix (e.g. .gcc, .clang)"
-        required: true
-        type: string
-      tag_suffix:
-        description: "Tag suffix (e.g. -gcc, -clang)"
-        required: true
-        type: string
   workflow_call:
     inputs:
       push:

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -1,16 +1,10 @@
 name: Build Ruby
 
 permissions:
+  contents: read
   packages: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      push:
-        description: Push images
-        required: true
-        type: boolean
-        default: true
   workflow_call:
     inputs:
       push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,38 @@
 name: Main
 
 on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: Push release images
+        required: true
+        type: boolean
+        default: true
   push:
     branches:
       - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.push && 'publish' || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   services:
     name: Services
     uses: ./.github/workflows/services.yml
+    with:
+      push: ${{ inputs.push && github.ref == 'refs/heads/main' }}
     permissions:
+      contents: read
       packages: write
 
   ruby:
     name: Ruby
     uses: ./.github/workflows/ruby.yml
+    with:
+      push: ${{ inputs.push && github.ref == 'refs/heads/main' }}
     permissions:
+      contents: read
       packages: write
 
   nix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,16 +1,10 @@
 name: Ruby
 
 permissions:
+  contents: read
   packages: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      push:
-        description: Push images
-        required: true
-        type: boolean
-        default: true
   workflow_call:
     inputs:
       push:

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -1,14 +1,12 @@
 name: Services
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       push:
-        description: Push images
-        required: true
+        required: false
         type: boolean
-        default: true
-  workflow_call:
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -42,6 +40,7 @@ jobs:
             arch: ["x86_64", "aarch64"]
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       packages: write
     name: Build (${{ matrix.service }})
     steps:


### PR DESCRIPTION
## Summary
- make Main the only manually dispatchable release workflow
- forward its guarded push input through the reusable workflow chain
- serialise release publication and make checkout and registry permissions explicit

## Validation
- nix run nixpkgs#actionlint -- .github/workflows/*.yml
- nix develop --command bundle exec rake docker:list

Actionlint reports existing shellcheck warnings in workflow run scripts.