### PR TITLE
Guard manual release inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     name: Services
     uses: ./.github/workflows/services.yml
     with:
-      push: ${{ inputs.push && github.ref == 'refs/heads/main' }}
+      push: ${{ github.event_name == 'workflow_dispatch' && inputs.push && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
       packages: write
@@ -30,7 +30,7 @@ jobs:
     name: Ruby
     uses: ./.github/workflows/ruby.yml
     with:
-      push: ${{ inputs.push && github.ref == 'refs/heads/main' }}
+      push: ${{ github.event_name == 'workflow_dispatch' && inputs.push && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- make reusable `push` inputs evaluate to `false` for push-triggered Main runs
- retain release publishing only for manual dispatches on `main`

## Root cause
PR #108 referenced the dispatch-only `inputs.push` value directly. GitHub evaluates that value as an empty string on push events, which is invalid for the reusable workflows boolean `push` input.

## Validation
- `nix run nixpkgs#actionlint -- -shellcheck= .github/workflows/*.yml`